### PR TITLE
Fix "Read more" link coverage: don't drop URLs with utm params, log pipeline counts

### DIFF
--- a/functions/src/summarize/generator.py
+++ b/functions/src/summarize/generator.py
@@ -454,6 +454,15 @@ If in doubt about whether content is unique or redundant, include the key findin
                     }
                 article_markers[id(article)] = marker_id
 
+        logger.info(
+            "Source registry built: %d unique URLs from %d items",
+            len(registry), len(sorted_content),
+        )
+        for mid, entry in list(registry.items())[:5]:
+            logger.info("  [S%d] %s — %s", mid, entry['source'][:60], entry['url'])
+        if len(registry) > 5:
+            logger.info("  ... and %d more", len(registry) - 5)
+
         return registry, article_markers
 
     @staticmethod
@@ -479,6 +488,16 @@ If in doubt about whether content is unique or redundant, include the key findin
         """
         if not text:
             return text
+
+        marker_matches = list(_MARKER_RE.finditer(text))
+        unknown_count = sum(
+            1 for m in marker_matches if int(m.group(1)) not in registry
+        )
+        expanded_count = len(marker_matches) - unknown_count
+        logger.info(
+            "Marker expansion: %d markers in text, %d expanded, %d dropped (id not in registry of %d)",
+            len(marker_matches), expanded_count, unknown_count, len(registry),
+        )
 
         def repl(match):
             entry = registry.get(int(match.group(1)))
@@ -519,10 +538,19 @@ If in doubt about whether content is unique or redundant, include the key findin
         valid = {_normalize_url(u) for u in (valid_urls or []) if u}
         try:
             soup = BeautifulSoup(html, 'html.parser')
-            for link in soup.find_all('a'):
+            anchors = list(soup.find_all('a'))
+            stripped = 0
+            for link in anchors:
                 href = link.get('href')
                 if not href or _normalize_url(href) not in valid:
+                    if href:
+                        logger.info("Stripping unvalidated anchor: %s", href)
                     link.replace_with(link.text)
+                    stripped += 1
+            logger.info(
+                "Anchor strip: %d anchors checked, %d kept, %d stripped (validity set: %d URLs)",
+                len(anchors), len(anchors) - stripped, stripped, len(valid),
+            )
             return str(soup)
         except Exception:
             logger.error("Error stripping unvalidated anchors", exc_info=True)
@@ -660,10 +688,6 @@ If in doubt about whether content is unique or redundant, include the key findin
             '/redirect/',
             '/track/',
             '/click?',
-            'utm_source=',
-            'utm_medium=',
-            'utm_campaign=',
-            'referrer=',
             '/ss/c/',
             'CL0/',
             'link.alphasignal.ai',

--- a/functions/tests/test_link_registry.py
+++ b/functions/tests/test_link_registry.py
@@ -63,6 +63,23 @@ class TestSourceRegistry:
         _, registry = generator._prepare_content_for_summary(items)
         assert set(registry.keys()) == {1}
 
+    def test_includes_article_with_utm_params(self, generator):
+        # Real article URLs frequently carry utm_* params from the campaign that
+        # delivered the newsletter. They must NOT be treated as tracking
+        # wrappers; otherwise the registry empties out and no link survives.
+        items = [
+            _item("Newsletter A", "x" * 200, [
+                {
+                    "title": "Real Article",
+                    "url": "https://verge.com/2026/05/24/ai?utm_source=tldr&utm_medium=email",
+                    "content": "y" * 200,
+                },
+            ]),
+        ]
+        _, registry = generator._prepare_content_for_summary(items)
+        assert len(registry) == 1
+        assert registry[1]["url"].startswith("https://verge.com/2026/05/24/ai")
+
     def test_excludes_tracking_and_root_urls(self, generator):
         items = [
             _item("Newsletter A", "x" * 200, [


### PR DESCRIPTION
## Summary

The first summary email produced after the link refactor merged was missing a lot of "Read more" links. Most likely root cause:

**`_is_tracking_url` was rejecting any URL that contained `utm_source=`, `utm_medium=`, `utm_campaign=`, or `referrer=`.** Newsletters routinely add those campaign params onto **destination article URLs** — those become the GET-final URL, then get false-flagged as tracking wrappers and dropped from the source registry. With no registry entry → no marker → the model has nothing to cite, so no link rendered.

`is_root_domain` also calls `_is_tracking_url`, so the same URLs were excluded twice over.

### Fix
- Drop `utm_*` and `referrer=` from the tracking-URL heuristic. We still reject real wrappers by domain (`beehiiv.com`, `substack.com`, `mailchimp.com`, …) and by path patterns (`/redirect/`, `/track/`, `/click?`, `/ss/c/`, `CL0/`, etc.). utm params on a destination URL are harmless — the link still resolves to the right article.

### Diagnostics
Adds `logger.info` lines so the next run shows in Cloud Functions logs:
- Source registry size and a sample of the URLs admitted.
- How many markers the model emitted vs expanded vs dropped as unknown.
- How many final anchors were kept vs stripped, plus the href of each stripped one.

If link gaps persist after this, those logs will tell us whether the cause is upstream (crawler dropping too many articles), the model not emitting markers, or a normalization mismatch in the safety strip.

## Test plan

- [x] `pytest` — 73 pass (1 new): a URL with `utm_source` + `utm_medium` is admitted to the registry.
- [ ] **Watch the next summary run's logs** for the new diagnostic lines and confirm the registry size and marker counts look reasonable.
- [ ] Manual: trigger "Send Summary Now" from the UI and confirm more sections now carry a working "Read more" link.

https://claude.ai/code/session_01UNSbZV6tYALgZepMgnpBV4

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNSbZV6tYALgZepMgnpBV4)_